### PR TITLE
Add node-based unit tests for cart and helper utilities

### DIFF
--- a/adminpanel/package.json
+++ b/adminpanel/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview --port 5001 --strictPort",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "dependencies": {
     "chart.js": "^4.4.5",

--- a/adminpanel/src/helpers/__tests__/utils.test.js
+++ b/adminpanel/src/helpers/__tests__/utils.test.js
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { separateAmount, formatDate } from '../utils.js';
+
+test('separateAmount adds a separator every three digits', () => {
+    assert.equal(separateAmount('1234567', ' '), '1 234 567');
+});
+
+test('separateAmount removes leading zeroes before formatting', () => {
+    assert.equal(separateAmount('0000456', ','), '456');
+});
+
+test('separateAmount keeps decimal values intact', () => {
+    assert.equal(separateAmount('12345.67'), '12 345.67');
+});
+
+test('separateAmount preserves negative amounts', () => {
+    assert.equal(separateAmount('-9876543', '.'), '-9.876.543');
+});
+
+test('formatDate returns a yyyy-mm-dd formatted string', () => {
+    assert.equal(formatDate('2023-11-05T00:00:00.000Z'), '2023-11-05');
+});
+
+test('formatDate pads month and day values', () => {
+    const date = new Date(2024, 0, 9);
+    assert.equal(formatDate(date), '2024-01-09');
+});

--- a/adminpanel/src/helpers/utils.js
+++ b/adminpanel/src/helpers/utils.js
@@ -1,16 +1,42 @@
-export function separateAmount(amount, separator) {
-    amount = ' ' + amount;
-    separator = separator || ' ';
-    let c = '',
-        d = 0;
-    while (amount.match(/^0[0-9]/)) {
-        amount = amount.substring(1);
+export function separateAmount(amount, separator = ' ') {
+    if (amount === undefined || amount === null) {
+        return '';
     }
-    for (let i = amount.length - 1; i >= 0; i--) {
-        c = (d != 0 && d % 3 == 0) ? amount[i] + separator + c : amount[i] + c;
-        d++;
+
+    const normalized = String(amount).trim();
+    if (normalized.length === 0) {
+        return '';
     }
-    return c;
+
+    const isNegative = normalized.startsWith('-');
+    const unsignedValue = isNegative ? normalized.slice(1) : normalized;
+    const decimalIndex = Math.max(unsignedValue.lastIndexOf('.'), unsignedValue.lastIndexOf(','));
+
+    let fractionSymbol = '';
+    let fractionDigits = '';
+
+    if (decimalIndex !== -1 && decimalIndex < unsignedValue.length - 1) {
+        fractionSymbol = unsignedValue[decimalIndex];
+        fractionDigits = unsignedValue.slice(decimalIndex + 1).replace(/\D/g, '');
+    }
+
+    const integerSource = decimalIndex !== -1 ? unsignedValue.slice(0, decimalIndex) : unsignedValue;
+    const integerDigitsRaw = integerSource.replace(/\D/g, '');
+    const integerDigits = integerDigitsRaw.replace(/^0+(?=\d)/, '');
+
+    if (!integerDigits && !fractionDigits) {
+        return '';
+    }
+
+    const formattedInteger = (integerDigits || '0').replace(/\B(?=(\d{3})+(?!\d))/g, separator);
+
+    if (!fractionDigits) {
+        return isNegative ? `-${formattedInteger}` : formattedInteger;
+    }
+
+    const decimalSeparator = fractionSymbol === ',' ? ',' : '.';
+    const formatted = `${formattedInteger}${decimalSeparator}${fractionDigits}`;
+    return isNegative ? `-${formatted}` : formatted;
 }
 
 export function formatDate(date) {

--- a/adminpanel/vite.config.js
+++ b/adminpanel/vite.config.js
@@ -24,6 +24,6 @@ export default defineConfig(({ mode }) => {
     },
     optimizeDeps: {
       exclude: ['/node_modules/'],
-    },
+    }
   }
 })

--- a/storefront/package.json
+++ b/storefront/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview --port 3000 --strictPort",
-    "serve": "vite preview --port 3000 --strictPort"
+    "serve": "vite preview --port 3000 --strictPort",
+    "test": "node --test"
   },
   "dependencies": {
     "autoprefixer": "^10.4.16",

--- a/storefront/src/__tests__/store.test.js
+++ b/storefront/src/__tests__/store.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createStore } from 'jotai';
+import { cartAtom, cartItemsQuantityAtom } from '../store.js';
+
+test('cartItemsQuantityAtom aggregates the total number of items', () => {
+    const store = createStore();
+    store.set(cartAtom, [
+        { id: 1, quantity: '2' },
+        { id: 2, quantity: '3' },
+        { id: 3, quantity: 1 },
+    ]);
+
+    assert.equal(store.get(cartItemsQuantityAtom), 6);
+});
+
+test('cartItemsQuantityAtom returns zero for an empty cart', () => {
+    const store = createStore();
+    store.set(cartAtom, []);
+
+    assert.equal(store.get(cartItemsQuantityAtom), 0);
+});


### PR DESCRIPTION
## Summary
- enable Node.js test scripts for the storefront and adminpanel microfrontends
- add coverage for the shared cart atom logic and admin utility helpers
- harden the amount formatter to better handle trimmed, decimal, and negative inputs

## Testing
- pnpm test (storefront)
- pnpm test (adminpanel)

------
https://chatgpt.com/codex/tasks/task_e_690c9b57c34483329aeb398d007442f1